### PR TITLE
Improvements to Camera Integration Plug

### DIFF
--- a/camera/api/serializers/position_preset.py
+++ b/camera/api/serializers/position_preset.py
@@ -38,12 +38,3 @@ class PositionPresetSerializer(serializers.ModelSerializer):
             msg = "Name should be unique. Another preset related to this bed already uses the same name."
             raise ValidationError(msg)
         return value
-
-    def create(self, validated_data):
-        validated_data["created_by"] = self.context["request"].user
-        validated_data["asset_bed"] = self.get_asset_bed_obj()
-        return super().create(validated_data)
-
-    def update(self, instance, validated_data):
-        validated_data["updated_by"] = self.context["request"].user
-        return super().update(instance, validated_data)

--- a/camera/api/viewsets/position_preset.py
+++ b/camera/api/viewsets/position_preset.py
@@ -77,6 +77,7 @@ class PositionPresetViewSet(ModelViewSet):
         return get_object_or_404(queryset)
 
     def get_queryset(self):
+        queryset = super().get_queryset()
         assetbed_external_id = self.request.query_params.get("assetbed_external_id")
         asset_external_id = self.request.query_params.get("asset_external_id")
         bed_external_id = self.request.query_params.get("bed_external_id")
@@ -92,19 +93,13 @@ class PositionPresetViewSet(ModelViewSet):
                 )
 
         if assetbed_external_id:
-            return super().get_queryset().filter(asset_bed=self.get_asset_bed_obj())
+            return queryset.filter(asset_bed=self.get_asset_bed_obj())
         if asset_external_id:
-            return (
-                super()
-                .get_queryset()
-                .filter(asset_bed__asset=self.get_asset_obj(asset_external_id))
+            return queryset.filter(
+                asset_bed__asset=self.get_asset_obj(asset_external_id)
             )
         if bed_external_id:
-            return (
-                super()
-                .get_queryset()
-                .filter(asset_bed__bed=self.get_bed_obj(bed_external_id))
-            )
+            return queryset.filter(asset_bed__bed=self.get_bed_obj(bed_external_id))
 
         raise NotFound
 

--- a/camera/api/viewsets/position_preset.py
+++ b/camera/api/viewsets/position_preset.py
@@ -1,12 +1,11 @@
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ValidationError, NotFound
-from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.viewsets import GenericViewSet, ModelViewSet
+from rest_framework.viewsets import ModelViewSet
+from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.types import OpenApiTypes
 
-from camera.api.serializers.position_preset import (
-    PositionPresetSerializer,
-)
+from camera.api.serializers.position_preset import PositionPresetSerializer
 from camera.models.position_preset import PositionPreset
 from care.utils.queryset.asset_bed import (
     get_asset_bed_queryset,
@@ -15,7 +14,7 @@ from care.utils.queryset.asset_bed import (
 )
 
 
-class AssetBedCameraPositionPresetViewSet(ModelViewSet):
+class PositionPresetViewSet(ModelViewSet):
     serializer_class = PositionPresetSerializer
     queryset = PositionPreset.objects.all().select_related(
         "asset_bed", "created_by", "updated_by"
@@ -23,38 +22,51 @@ class AssetBedCameraPositionPresetViewSet(ModelViewSet):
     lookup_field = "external_id"
     permission_classes = (IsAuthenticated,)
 
-    def get_asset_bed_obj(self):
-        assetbed_external_id = self.request.query_params.get("assetbed_external_id")
-        if not assetbed_external_id:
-            raise ValidationError(
-                detail="'assetbed_external_id' must be provided."
-            )
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="assetbed_external_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="External ID of the asset bed",
+            ),
+        ]
+    )
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="assetbed_external_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="External ID of the asset bed",
+            ),
+            OpenApiParameter(
+                name="asset_external_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="External ID of the asset",
+            ),
+            OpenApiParameter(
+                name="bed_external_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="External ID of the bed",
+            ),
+        ],
+        description="At least one of assetbed_external_id, asset_external_id, or bed_external_id must be provided",
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    def get_asset_bed_obj(self, external_id: str):
         queryset = get_asset_bed_queryset(self.request.user).filter(
-            external_id=assetbed_external_id
+            external_id=external_id
         )
         return get_object_or_404(queryset)
-
-    def get_queryset(self):
-        assetbed_external_id = self.request.query_params.get("assetbed_external_id")
-        if not assetbed_external_id:
-            raise ValidationError(
-                detail="'assetbed_external_id' must be provided."
-            )
-        return super().get_queryset().filter(asset_bed=self.get_asset_bed_obj())
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context["asset_bed"] = self.get_asset_bed_obj()
-        return context
-
-
-class PresetPositionViewSet(GenericViewSet, ListModelMixin):
-    serializer_class = PositionPresetSerializer
-    queryset = PositionPreset.objects.all().select_related(
-        "asset_bed", "created_by", "updated_by"
-    )
-    lookup_field = "external_id"
-    permission_classes = (IsAuthenticated,)
 
     def get_bed_obj(self, external_id: str):
         queryset = get_bed_queryset(self.request.user).filter(external_id=external_id)
@@ -65,19 +77,47 @@ class PresetPositionViewSet(GenericViewSet, ListModelMixin):
         return get_object_or_404(queryset)
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        assetbed_external_id = self.request.query_params.get("assetbed_external_id")
         asset_external_id = self.request.query_params.get("asset_external_id")
         bed_external_id = self.request.query_params.get("bed_external_id")
 
-        if not (asset_external_id or bed_external_id):
-            raise ValidationError(
-                detail="Either 'asset_external_id' or 'bed_external_id' must be provided."
-            )
+        if self.action == "create":
+            if not assetbed_external_id:
+                raise ValidationError(detail="'assetbed_external_id' must be provided.")
 
+        if self.action == "list":
+            if not (assetbed_external_id or asset_external_id or bed_external_id):
+                raise ValidationError(
+                    detail="'assetbed_external_id' or 'asset_external_id' or 'bed_external_id' must be provided."
+                )
+
+        if assetbed_external_id:
+            return super().get_queryset().filter(asset_bed=self.get_asset_bed_obj())
         if asset_external_id:
-            return queryset.filter(
-                asset_bed__asset=self.get_asset_obj(asset_external_id)
+            return (
+                super()
+                .get_queryset()
+                .filter(asset_bed__asset=self.get_asset_obj(asset_external_id))
             )
         if bed_external_id:
-            return queryset.filter(asset_bed__bed=self.get_bed_obj(bed_external_id))
+            return (
+                super()
+                .get_queryset()
+                .filter(asset_bed__bed=self.get_bed_obj(bed_external_id))
+            )
+
         raise NotFound
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.action == "create":
+            context["asset_bed"] = self.get_asset_bed_obj()
+        return context
+
+    def perform_create(self, serializer):
+        serializer.save(
+            asset_bed=self.get_asset_bed_obj(), created_by=self.request.user
+        )
+
+    def perform_update(self, serializer):
+        serializer.save(updated_by=self.request.user)

--- a/camera/migrations/0002_auto_20241121_1505.py
+++ b/camera/migrations/0002_auto_20241121_1505.py
@@ -11,7 +11,7 @@ def migrate_camera_preset_to_position_preset(apps, schema_editor):
 
     position_presets = [
         PositionPreset(
-            id=preset.id,
+            external_id=preset.external_id,
             name=preset.name,
             asset_bed=preset.asset_bed,
             position=preset.position,

--- a/camera/migrations/0002_auto_20241121_1505.py
+++ b/camera/migrations/0002_auto_20241121_1505.py
@@ -4,7 +4,12 @@ from django.db import migrations
 
 
 def migrate_camera_preset_to_position_preset(apps, schema_editor):
-    CameraPreset = apps.get_model("facility", "CameraPreset")
+    try:
+        CameraPreset = apps.get_model("facility", "CameraPreset")
+    except LookupError:
+        # If CameraPreset model doesn't exist, skip the migration
+        return
+
     PositionPreset = apps.get_model("camera", "PositionPreset")
 
     camera_presets = CameraPreset.objects.all()

--- a/camera/urls.py
+++ b/camera/urls.py
@@ -1,21 +1,12 @@
 from rest_framework.routers import DefaultRouter
-from camera.api.viewsets.position_preset import (
-    AssetBedCameraPositionPresetViewSet,
-    PresetPositionViewSet,
-)
+from camera.api.viewsets.position_preset import PositionPresetViewSet
 
 camera_router = DefaultRouter()
 
 camera_router.register(
-    r"assetbed/position_presets",
-    AssetBedCameraPositionPresetViewSet,
-    basename="assetbed-camera-presets",
-)
-
-camera_router.register(
-    r"position_presets",
-    PresetPositionViewSet,
-    basename="camera-presets",
+    r"position-presets",
+    PositionPresetViewSet,
+    basename="camera-position-presets",
 )
 
 


### PR DESCRIPTION
### Proposed Changes

- Fixes #1
- When migrating from old `CameraPreset` model from main care, copy the `external_id` and skip copying the PK `id`
- Skip copying from old `CameraPreset` model from main care if the source model no longer exists.
- Simplify the APIs (One viewset, requires asset_bed UUID for create's, requires one of asset_bed or bed or asset's UUID for list).

### APIs (Before)

<img width="809" alt="image" src="https://github.com/user-attachments/assets/c8d00ac0-bebd-4f58-9a18-8ece2a495288">


### APIs (After)

<img width="802" alt="image" src="https://github.com/user-attachments/assets/5c172440-6a9e-4aa5-97a2-dc80429cb1d0">

### List APIs (Before)

<img width="795" alt="image" src="https://github.com/user-attachments/assets/c81854a3-7886-4938-bf3d-d2ceb1e4c8d1">

<img width="801" alt="image" src="https://github.com/user-attachments/assets/57eb72a6-04bb-4db4-bbd7-d7abd762a3e1">



### List API (After)

<img width="809" alt="image" src="https://github.com/user-attachments/assets/3c7d6ff2-92f3-4186-ae76-f89bd1e25d28">

